### PR TITLE
Bug/fix GitHub workflow builds for xp

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -8,12 +8,9 @@ permissions:
 
 jobs:
   build:
-    runs-on: ubuntu-22.04
+    runs-on: windows-latest
     steps:
       - uses: actions/checkout@v4
-
-      - name: Install MinGW cross-compiler
-        run: sudo apt-get update && sudo apt-get install -y gcc-mingw-w64-i686 g++-mingw-w64-i686
 
       - name: Configure
         run: cmake --preset release

--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 # Build output
 build/
+toolchain/
 build-check/
 out/
 tools/

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,39 @@
 cmake_minimum_required(VERSION 3.20)
+
+# Auto-provision MinGW toolchain (GCC 12.2.0, win32 threads, XP-safe)
+set(TOOLCHAIN_DIR "${CMAKE_SOURCE_DIR}/toolchain/mingw32")
+if(NOT EXISTS "${TOOLCHAIN_DIR}/bin/gcc.exe")
+    set(TOOLCHAIN_URL "https://github.com/niXman/mingw-builds-binaries/releases/download/12.2.0-rt_v10-rev2/i686-12.2.0-release-win32-dwarf-msvcrt-rt_v10-rev2.7z")
+    set(TOOLCHAIN_ARCHIVE "${CMAKE_SOURCE_DIR}/toolchain/mingw-toolchain.7z")
+    message(STATUS "Downloading MinGW toolchain...")
+    file(DOWNLOAD "${TOOLCHAIN_URL}" "${TOOLCHAIN_ARCHIVE}" SHOW_PROGRESS STATUS dl_status)
+    list(GET dl_status 0 dl_code)
+    if(NOT dl_code EQUAL 0)
+        message(FATAL_ERROR "Toolchain download failed: ${dl_status}")
+    endif()
+    message(STATUS "Extracting toolchain...")
+    execute_process(
+        COMMAND ${CMAKE_COMMAND} -E tar xf "${TOOLCHAIN_ARCHIVE}"
+        WORKING_DIRECTORY "${CMAKE_SOURCE_DIR}/toolchain"
+        RESULT_VARIABLE extract_result
+    )
+    if(NOT extract_result EQUAL 0)
+        # cmake tar doesn't handle 7z — fall back to 7z command
+        execute_process(
+            COMMAND 7z x "${TOOLCHAIN_ARCHIVE}" -o"${CMAKE_SOURCE_DIR}/toolchain" -y
+            RESULT_VARIABLE extract_result
+        )
+        if(NOT extract_result EQUAL 0)
+            message(FATAL_ERROR "Toolchain extraction failed")
+        endif()
+    endif()
+    file(REMOVE "${TOOLCHAIN_ARCHIVE}")
+endif()
+
+set(CMAKE_C_COMPILER "${TOOLCHAIN_DIR}/bin/gcc.exe" CACHE FILEPATH "" FORCE)
+set(CMAKE_CXX_COMPILER "${TOOLCHAIN_DIR}/bin/g++.exe" CACHE FILEPATH "" FORCE)
+set(CMAKE_RC_COMPILER "${TOOLCHAIN_DIR}/bin/windres.exe" CACHE FILEPATH "" FORCE)
+
 project(2EZConfig VERSION 1.0.0 LANGUAGES C CXX)
 
 set(CMAKE_CXX_STANDARD 17)

--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -4,14 +4,8 @@
         {
             "name": "_base",
             "hidden": true,
-            "binaryDir": "${sourceDir}/build/${presetName}",
-            "cacheVariables": {
-                "CMAKE_SYSTEM_NAME": "Windows",
-                "CMAKE_SYSTEM_PROCESSOR": "i686",
-                "CMAKE_C_COMPILER": "i686-w64-mingw32-gcc",
-                "CMAKE_CXX_COMPILER": "i686-w64-mingw32-g++",
-                "CMAKE_RC_COMPILER": "i686-w64-mingw32-windres"
-            }
+            "generator": "MinGW Makefiles",
+            "binaryDir": "${sourceDir}/build/${presetName}"
         },
         {
             "name": "release",

--- a/README.md
+++ b/README.md
@@ -31,12 +31,9 @@ If you're playing on Windows Vista or later I highly reccomend using [DDrawCompa
 I will accept PR's for updates to the patches.json file if they seem appropriate. 
 
 ## Building
-All builds are done on linux with mingw32
+All builds are done on windows with cmake and niXman mingw32 gcc 12.2.0 toolchain
 
-Install build tools
-```sudo apt install cmake git gcc-mingw-w64-i686 g++-mingw-w64-i686 binutils-mingw-w64-i686```
-
-Load Dependancies
+Download toolchain and Dependancies
 ```cmake --preset release```
 
 Build


### PR DESCRIPTION
Switched to windows workflows for easier time building WinXP compatible binaries. ubuntu-latest uses gcc 13+ which forces vista or newer api's in some base dependacies which cannot be bypassed with build parameters. Switching to windows lets me use a nixman prebuilt toolchain for mingw with gcc 12.2.0 which still supports winxp binaries.

cmake has been updated to automatically download this toolchain when ran the first time locally.

closes https://github.com/ben-rnd/2EZConfig-V2/issues/3