### PR TITLE
Add Skip UI checkbox to settings tab

### DIFF
--- a/src/2ezconfig-exe/main.cpp
+++ b/src/2ezconfig-exe/main.cpp
@@ -687,6 +687,11 @@ static void renderSettingsTab() {
     globalCheckbox("Enable IO Emulation",                "io_emu",       true);
     globalCheckbox("Force High Priority (experimental)", "high_priority", false);
 
+    ImGui::SeparatorText("Launch Settings");
+    gameCheckbox("Skip UI (boot directly into game)", "skip_ui", false);
+    if (ImGui::IsItemHovered())
+        ImGui::SetTooltip("Bypasses the config UI and launches the game immediately.\nGreat for arcade-like setups. Use -skip-config on the command line\nfor a one-time bypass, or edit skip_ui in game-settings.json to revert.");
+
     ImGui::SeparatorText("Debug Settings");
     gameCheckbox("Enable Logging", "logging_enabled", false);
     {


### PR DESCRIPTION
## Summary

- The README advertises a "Skip UI" option to boot directly into the game once settings are set, but the actual checkbox to enable it was missing from the settings tab.
- The runtime support is already in place: `main.cpp:256` checks `gameSettings().value("skip_ui", false)`, and `settings.cpp:24` includes `skip_ui` in the default game settings — only the GUI toggle was unwired.
- Adds a single `gameCheckbox` under a new "Launch Settings" separator with a tooltip pointing at `-skip-config` and `game-settings.json` as the existing escape hatches.

## Test plan

- [ ] Build with `cmake --build --preset release` and confirm `2EZConfig.exe` launches.
- [ ] On the Settings tab, verify "Skip UI (boot directly into game)" appears under a "Launch Settings" header between Global Settings and Debug Settings.
- [ ] Toggle the checkbox on, close 2EZConfig, relaunch — game should boot directly without showing the UI.
- [ ] Hover the checkbox to confirm the tooltip mentions `-skip-config` and `game-settings.json`.
- [ ] Disable by editing `game-settings.json` (`"skip_ui": false`) and confirm UI returns on next launch.