### PR TITLE
Port V1 autoplay hotkey toggle for late EZ2AC titles

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -167,6 +167,7 @@ add_subdirectory(src/libs/patches)
 add_subdirectory(src/libs/settings)
 add_subdirectory(src/libs/input)
 add_subdirectory(src/libs/bindings)
+add_subdirectory(src/libs/autoplay)
 add_subdirectory(src/2ezconfig-exe)
 add_subdirectory(src/2ez-dll)
 

--- a/src/2ez-dll/CMakeLists.txt
+++ b/src/2ez-dll/CMakeLists.txt
@@ -39,6 +39,7 @@ target_link_libraries(2EZ PRIVATE
     patches
     logger
     utilities
+    autoplay
     kernel32
     user32
     winmm

--- a/src/2ez-dll/dll.cpp
+++ b/src/2ez-dll/dll.cpp
@@ -10,6 +10,7 @@
 #include "ez2dj_io.h"
 #include "ez2dancer_io.h"
 #include "sabin_io.h"
+#include "autoplay.h"
 #include "bindings.h"
 #include "input_manager.h"
 #include "patch_store.h"
@@ -94,6 +95,7 @@ static DWORD WINAPI InitThread(void*) {
     //Initialise the appropriate IO handler based on game family
     switch (s_gameFamily) {
         case GameFamily::EZ2DJ:
+            Autoplay::init(s_gameId);
             EZ2DJIO::initialiseIO(&s_bindings, s_input, s_settings);
             break;
         case GameFamily::EZ2Dancer:

--- a/src/libs/autoplay/CMakeLists.txt
+++ b/src/libs/autoplay/CMakeLists.txt
@@ -1,0 +1,5 @@
+add_library(autoplay STATIC autoplay.cpp)
+target_include_directories(autoplay
+    PUBLIC ${CMAKE_CURRENT_SOURCE_DIR}
+)
+target_link_libraries(autoplay PRIVATE logger kernel32 user32)

--- a/src/libs/autoplay/autoplay.cpp
+++ b/src/libs/autoplay/autoplay.cpp
@@ -1,0 +1,89 @@
+#include "autoplay.h"
+#include "logger.h"
+
+#include <windows.h>
+#include <atomic>
+
+namespace {
+
+struct GameOffset {
+    const char* gameId;
+    uintptr_t   offset;
+};
+
+// Offsets ported verbatim from V1 2EZ.cpp alternateInputThread.
+constexpr GameOffset GAME_OFFSETS[] = {
+    { "ez2ac_fn",    0x175E290 },   // Final
+    { "ez2ac_fn_ex", 0x175F2E0 },   // Final:EX
+    { "ez2ac_nt",    0x1360EA4 },   // Night Traveller
+    { "ez2ac_ec",    0x00EF606C },  // Endless Circulation
+};
+
+// Default hotkey matches V1 default (VK_F11).
+constexpr int DEFAULT_HOTKEY = VK_F11;
+
+uintptr_t g_apAddr   = 0;
+int       g_hotkey   = DEFAULT_HOTKEY;
+std::atomic<bool> g_running{false};
+
+void toggleByte() {
+    uint8_t* target = reinterpret_cast<uint8_t*>(g_apAddr);
+    DWORD oldProtect = 0;
+    if (!VirtualProtect(target, 1, PAGE_EXECUTE_READWRITE, &oldProtect)) {
+        Logger::warn("[Autoplay] VirtualProtect failed");
+        return;
+    }
+    *target = (*target == 0) ? 1 : 0;
+    VirtualProtect(target, 1, oldProtect, &oldProtect);
+}
+
+DWORD WINAPI hotkeyThread(LPVOID) {
+    bool pressed = false;
+    while (g_running.load()) {
+        bool down = (GetAsyncKeyState(g_hotkey) & 0x8000) != 0;
+        if (down && !pressed) {
+            toggleByte();
+            uint8_t state = *reinterpret_cast<uint8_t*>(g_apAddr);
+            Logger::info(std::string("[Autoplay] Toggled -> ") + (state ? "ON" : "OFF"));
+        }
+        pressed = down;
+        Sleep(16);
+    }
+    return 0;
+}
+
+uintptr_t resolveOffset(const std::string& gameId) {
+    for (const auto& entry : GAME_OFFSETS) {
+        if (gameId == entry.gameId) return entry.offset;
+    }
+    return 0;
+}
+
+}  // namespace
+
+namespace Autoplay {
+
+void init(const std::string& gameId) {
+    uintptr_t offset = resolveOffset(gameId);
+    if (offset == 0) {
+        return;  // Game not in the supported list.
+    }
+
+    uintptr_t base = reinterpret_cast<uintptr_t>(GetModuleHandleA(nullptr));
+    if (base == 0) {
+        Logger::error("[Autoplay] Could not resolve module base");
+        return;
+    }
+
+    g_apAddr = base + offset;
+    g_running.store(true);
+    CreateThread(nullptr, 0, hotkeyThread, nullptr, 0, nullptr);
+
+    char keyName[32] = {};
+    int sc = MapVirtualKeyA(g_hotkey, MAPVK_VK_TO_VSC);
+    GetKeyNameTextA(sc << 16, keyName, sizeof(keyName));
+    Logger::info(std::string("[Autoplay] Armed for ") + gameId +
+                 " (hotkey: " + (keyName[0] ? keyName : "F11") + ")");
+}
+
+}  // namespace Autoplay

--- a/src/libs/autoplay/autoplay.h
+++ b/src/libs/autoplay/autoplay.h
@@ -1,0 +1,18 @@
+#pragma once
+
+#include <string>
+
+// Hotkey-driven autoplay toggle. Mirrors 2EZConfig V1 behavior:
+// tapping the configured key flips a single byte at a game-specific
+// offset, toggling the game's internal autoplay flag.
+//
+// Supported game IDs (others are no-ops):
+//   ez2ac_fn      — Final
+//   ez2ac_fn_ex   — Final:EX
+//   ez2ac_nt      — Night Traveller
+//   ez2ac_ec      — Endless Circulation
+namespace Autoplay {
+
+void init(const std::string& gameId);
+
+}  // namespace Autoplay


### PR DESCRIPTION
## Summary

- Restores the autoplay hotkey feature that existed in 2EZConfig V1 but was dropped during the V2 rewrite. V1's \`alternateInputThread\` mapped F11 to a single-byte toggle at a game-specific offset for Final, Final:EX, Night Traveller, and Endless Circulation — useful for practice and demos.
- New \`src/libs/autoplay/\` module: tiny header + a single polling thread that runs only when the active \`game_id\` matches one of the four supported titles. Hidden behind an early-return for every other game, so this is a zero-impact change for unaffected titles.
- Offsets are copied verbatim from V1 \`2EZ.cpp\`:
  - \`ez2ac_fn\`    → \`0x175E290\`
  - \`ez2ac_fn_ex\` → \`0x175F2E0\`
  - \`ez2ac_nt\`    → \`0x1360EA4\`
  - \`ez2ac_ec\`    → \`0x00EF606C\`

## Differences from V1

- **Polling**: \`Sleep(16)\` (~60 Hz) instead of V1's tight busy-loop. V1's \`Sleep(1)\` is placed after \`while(true)\`, which is unreachable — so the thread pegged a CPU core. The 16 ms cadence is more than fast enough for a human-tap toggle and won't miss presses (a physical key tap is ~50–100 ms).
- **Note judgment**: unaffected. The hotkey thread is fully separate from the IO/input path (\`EZ2DJIO::installHooks\`), so polling rate has no bearing on timing.
- **Toggle math**: clean \`byte == 0 ? 1 : 0\` instead of V1's \`1 + (0 - x)\`, which produced negative values for non-{0,1} bytes.
- **Hotkey**: hard-coded to \`VK_F11\` (V1 default). Easy to lift into \`global-settings.json\` later if needed — kept it simple to minimise PR surface.

## Test plan

- [ ] Build with \`cmake --build --preset release\` and confirm \`2EZ.dll\` links cleanly.
- [ ] Launch Final / Final:EX / Night Traveller / Endless Circulation and confirm logs show \`[Autoplay] Armed for <game_id> (hotkey: F11)\`.
- [ ] Tap F11 in-game and verify the game's autoplay flag toggles; log shows \`[Autoplay] Toggled -> ON\` / \`OFF\` on each press.
- [ ] Launch a non-supported title (e.g. 7th Trax) and confirm the autoplay module is silent (no log lines, F11 inert).